### PR TITLE
Fix number of watchers

### DIFF
--- a/api.py
+++ b/api.py
@@ -134,7 +134,7 @@ class DataJsonHandler(tornado.web.RequestHandler):
         data = {
             "stats": {
                 "stargazers": repo["stargazers_count"],
-                "watchers": repo["watchers_count"],
+                "watchers": repo["subscribers_count"],
                 "forks": repo["forks_count"],
                 "contributors": len(contributors),
                 "translations": int(translations["count"]),


### PR DESCRIPTION
This fixes the number of watchers which was equal to the stargazers_count before. The naming in the GitHub API is a bit weird and was caused by the introduction of stars back in 2012: https://developer.github.com/changes/2012-09-05-watcher-api/

I didn't test the changes yet, but I think this shouldn't be a problem.