### PR TITLE
Determine contributors count using basic web scraping

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 tornado>=4.0
+lxml
+cssselect


### PR DESCRIPTION
Implements the same feature as #4, but using web scraping, therefore requiring only a single request. Also, by avoiding the GitHub API but parsing the GitHub website, the rate limit isn't bloated.