### PR TITLE
Make Dependabot ignore beta Python versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "python"
+        versions:
+          - "*.*.*b*"
 
   - package-ecosystem: "pip"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
     ignore:
       - dependency-name: "python"
         versions:
+          - "*.*.*a*"
           - "*.*.*b*"
 
   - package-ecosystem: "pip"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "python"
-        versions:
-          - "*.*.*a*"
-          - "*.*.*b*"
+    allow:
+      # ignore prereleases by allowing just semver patch release changes
+      - update-types:
+        - "version-update:semver-patch"
 
   - package-ecosystem: "pip"
     directory: "/"


### PR DESCRIPTION
Should prevent PRs like #147 from being created by Dependabot.